### PR TITLE
feat: Add configurable blank line detection and content splitting control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2]
+
+
+
 ## [0.1.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.2]
 
+### Added
+- Added `--no-split-content` flag to prevent content blocks from being split across pages
+- Added `--blank-ratio` argument to control strictness of blank line detection
 
 
 ## [0.1.1]

--- a/scrollshot2pdf.py
+++ b/scrollshot2pdf.py
@@ -510,6 +510,10 @@ def create_pdf(
                     "  3. If your image has small whitespace breaks, try a smaller --min-gap value to detect them as split points.",
                     file=sys.stderr,
                 )
+                print(
+                    "  4. If your image's blank areas have noise, try --blank-ratio to allow for imperfectly blank lines.",
+                    file=sys.stderr,
+                )
                 sys.exit(1)
 
             slice_img = image.crop((0, start_y, image.size[0], end_y))
@@ -588,7 +592,7 @@ def main():
     parser.add_argument(
         "--no-split-content",
         action="store_true",
-        help="Never split content blocks; creates longer pages if necessary.",
+        help="Prevents content blocks from being split. Will error if a block is too tall to fit on a single page.",
     )
 
     # Add page numbering arguments


### PR DESCRIPTION
## Summary
This PR adds two new features to improve page break control:
- `--blank-ratio`: Makes blank line detection configurable, allowing for noisy images 
- `--no-split-content`: Prevents content blocks from being split across pages

## Details

### Blank Line Detection (`--blank-ratio`)
- Default (0.0): Strict behavior - all pixels must be > 250 brightness
- With value > 0: Allow specified ratio of non-blank pixels (e.g., 0.1 = 10% tolerance)
- Particularly useful for images with compression artifacts or subtle backgrounds

### Content Splitting Control (`--no-split-content`)
- Default: Content may be split at page boundaries if no gap is found
- With flag: Forces splits to occur only at content gaps, never cutting through content
- Includes helpful error handling when content blocks are too tall for selected page size

## Usage Examples
```bash
# Allow 15% non-blank pixels in "blank" lines
scrollshot2pdf image.png --blank-ratio 0.15

# Prevent content from being split across pages
scrollshot2pdf document.png --no-split-content --page-size legal
```
